### PR TITLE
Fixup for 'queries' endpoint

### DIFF
--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,4 +1,10 @@
-def test_request(client):
+def test_appliance_query(client):
+    response = client.get('/queries', query_string={'type': 'appliances'})
+
+    assert 'blender' in response.json
+
+
+def test_utensil_query(client):
     response = client.get('/queries', query_string={'type': 'utensils'})
 
     assert 'whisk' in response.json

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,2 +1,4 @@
 def test_request(client):
-    client.post('/')
+    response = client.get('/queries', query_string={'type': 'appliances'})
+
+    assert 'whisk' in response.json

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,4 +1,4 @@
 def test_request(client):
-    response = client.get('/queries', query_string={'type': 'appliances'})
+    response = client.get('/queries', query_string={'type': 'utensils'})
 
     assert 'whisk' in response.json

--- a/web/app.py
+++ b/web/app.py
@@ -19,7 +19,7 @@ def queries():
     if query_type == 'appliances':
         return jsonify(appliance_queries)
     if query_type == 'utensils':
-        return jsonify(appliance_queries)
+        return jsonify(utensil_queries)
     return abort(404)
 
 

--- a/web/app.py
+++ b/web/app.py
@@ -15,12 +15,15 @@ utensil_queries = load_queries('web/data/utensils.txt')
 
 @app.route('/queries')
 def queries():
+    queries_by_type = {
+        'appliances': appliance_queries,
+        'utensils': utensil_queries,
+    }
     query_type = request.args.get('type')
-    if query_type == 'appliances':
-        return jsonify(appliance_queries)
-    if query_type == 'utensils':
-        return jsonify(utensil_queries)
-    return abort(404)
+    queries = queries_by_type.get(query_type)
+    if not queries:
+        return abort(404)
+    return jsonify(queries)
 
 
 @app.route('/', methods=['POST'])


### PR DESCRIPTION
A query on `type: appliances` was returning the list of `utensil` queries.