### PR TITLE
Add list of vessels for direction parsing

### DIFF
--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -8,3 +8,9 @@ def test_utensil_query(client):
     response = client.get('/queries', query_string={'type': 'utensils'})
 
     assert 'whisk' in response.json
+
+
+def test_vessel_query(client):
+    response = client.get('/queries', query_string={'type': 'vessels'})
+
+    assert 'dutch oven' in response.json

--- a/web/app.py
+++ b/web/app.py
@@ -11,6 +11,7 @@ app = Flask(__name__)
 
 appliance_queries = load_queries('web/data/appliances.txt')
 utensil_queries = load_queries('web/data/utensils.txt')
+vessel_queries = load_queries('web/data/vessels.txt')
 
 
 @app.route('/queries')
@@ -18,6 +19,7 @@ def queries():
     queries_by_type = {
         'appliances': appliance_queries,
         'utensils': utensil_queries,
+        'vessels': vessel_queries,
     }
     query_type = request.args.get('type')
     queries = queries_by_type.get(query_type)
@@ -33,6 +35,7 @@ def root():
     index = build_search_index(descriptions)
     appliance_hits = execute_queries(index, appliance_queries)
     utensil_hits = execute_queries(index, utensil_queries)
+    vessel_hits = execute_queries(index, vessel_queries)
 
     results = []
     for doc_id, description in enumerate(descriptions):
@@ -46,6 +49,10 @@ def root():
             'utensils': [
                 {'utensil': utensil}
                 for utensil in utensil_hits[doc_id]
+            ],
+            'vessels': [
+                {'vessel': vessel}
+                for vessel in vessel_hits[doc_id]
             ],
         })
     return jsonify(results)

--- a/web/data/vessels.txt
+++ b/web/data/vessels.txt
@@ -1,0 +1,52 @@
+Bain-marie
+Beanpot
+Billycan
+Bratt pan
+Bread pan
+Caquelon
+Casserole
+Cassole
+Cassolette
+Cast-iron cookware
+Cataplana
+Cauldron
+Chafing dish
+Chip pan
+Crepulja
+Crock
+Dolsot
+Double boiler
+Dutch oven
+Fish kettle
+French tian
+Frying pan
+Tava
+Gamasot
+Handi
+Karahi
+Kazan
+Marmite
+Mold
+Muffin tin
+Olla
+Pipkin
+Palayok
+Porringer
+Potjie
+Pressure cooker
+Ramekin
+Rice cooker
+Roasting pan
+Sinseollo
+Siru
+Slow cooker
+Springform pan
+Stock pot
+Sufuria
+Tajine
+Tangia
+Tapayan
+Terrine
+Ttukbaegi
+Uruli
+Wok


### PR DESCRIPTION
There's some duplication here (`rice cooker` appears in all three lists), but that's not necessarily a problem.

```
cat web/data/*.txt | sort | uniq -c | grep -vw 1
...
      3 Rice cooker
...
```
