### PR TITLE
Pipfile dependency updates

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,14 +4,14 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-flask = "*"
-gunicorn = "*"
-hashedindex = "*"
-stop-words = "*"
+flask = "==1.1.1"
+gunicorn = "==20.0.4"
+hashedindex = "==0.5.0"
+stop-words = "==2018.7.23"
 
 [dev-packages]
 flake8 = "*"
-pytest = "==4.6.5"
+pytest = "*"
 
 [requires]
 python_version = "3.7"


### PR DESCRIPTION
Build:

- Now that https://github.com/benoitc/gunicorn/pull/2187 is released, we can upgrade to `gunicorn==20.0.4` (verified via local testing)
- Pin remaining dependencies to latest release versions

Dev:
- Unpin `pytest` dependency (this is a holdover from [ingredient-parser](https://www.github.com/openculinary/ingredient-parser) which is a py2.7 service)