### PR TITLE
Retain input formatting

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -18,4 +18,4 @@ flake8 = "*"
 pytest = "*"
 
 [packages.797bd8b]
-path = "https://github.com/openculinary/hashedixsearch/raw/e615320eb26c6fe0ab47e258c394db902c1d6ec5/dist/hashedixsearch-0.1.2rc0-py3-none-any.whl"
+path = "https://github.com/openculinary/hashedixsearch/raw/7e5dd00454a889e68dea580a0cafe5f51bf5344b/dist/hashedixsearch-0.1.2rc1-py3-none-any.whl"

--- a/Pipfile
+++ b/Pipfile
@@ -9,10 +9,13 @@ python_version = "3.7"
 [packages]
 flask = "==1.1.1"
 gunicorn = "==20.0.4"
-hashedixsearch = "==0.1.1"
+hashedindex = { git = "https://github.com/jayaddison/hashedindex.git", ref = "3a7e46a22c04960a0a50a2fca2d25cee7b4f9267" }
 stop-words = "==2018.7.23"
 snowballstemmer = "==2.0.0"
 
 [dev-packages]
 flake8 = "*"
 pytest = "*"
+
+[packages.797bd8b]
+path = "https://github.com/openculinary/hashedixsearch/raw/e615320eb26c6fe0ab47e258c394db902c1d6ec5/dist/hashedixsearch-0.1.2rc0-py3-none-any.whl"

--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,6 @@ python_version = "3.7"
 [packages]
 flask = "==1.1.1"
 gunicorn = "==20.0.4"
-hashedindex = { git = "https://github.com/jayaddison/hashedindex.git", ref = "3a7e46a22c04960a0a50a2fca2d25cee7b4f9267" }
 stop-words = "==2018.7.23"
 snowballstemmer = "==2.0.0"
 
@@ -17,5 +16,9 @@ snowballstemmer = "==2.0.0"
 flake8 = "*"
 pytest = "*"
 
-[packages.797bd8b]
-path = "https://github.com/openculinary/hashedixsearch/raw/7e5dd00454a889e68dea580a0cafe5f51bf5344b/dist/hashedixsearch-0.1.2rc1-py3-none-any.whl"
+[packages.hashedindex]
+git = "https://github.com/jayaddison/hashedindex.git"
+ref = "3a7e46a22c04960a0a50a2fca2d25cee7b4f9267"
+
+[packages.hashedixsearch]
+file = "https://github.com/openculinary/hashedixsearch/raw/6068f9173f0f9910994c47a5c98b565dd275d51e/dist/hashedixsearch-0.2.0rc0-py3-none-any.whl"

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -18,8 +18,8 @@ def test_vessel_queries(client):
 
 def test_description_parsing(client):
     description_equipment = {
-        'pre-heat the oven': {
-            'markup': 'preheat the <mark>oven</mark>',
+        'Pre-heat the oven to 250 degrees F.': {
+            'markup': 'Pre-heat the <mark>oven</mark> to 250 degrees F.',
             'appliances': ['oven'],
         },
         'leave the slow cooker on a low heat': {

--- a/web/app.py
+++ b/web/app.py
@@ -93,8 +93,7 @@ def root():
         markup_by_doc[doc_id] = highlight(
             query=description,
             terms=terms,
-            stemmer=stemmer,
-            analyzer=None
+            stemmer=stemmer
         )
 
     results = []


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Currently the direction parser drops most of the contextual formatting and character casing from the input direction text.

This results in phrases like `Pre-heat the oven` being transformed into `preheat the oven`.  

In many situations that is still comprehensible to the end-user; but in some cases valuable context provided by the author may be lost.

This pull request introduces some recently-added functionality from the [hashedixsearch](https://github.com/openculinary/hashedixsearch) library to retain input formatting.

### Briefly summarize the changes
1. Switch to custom [hashedixsearch](https://github.com/openculinary/hashedixsearch) version

### How have the changes been tested?
1. Unit coverage is provided
