### PR TITLE
Perform case-insensitive highlighting

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,7 @@ python_version = "3.8"
 [packages]
 flask = "==1.1.1"
 gunicorn = "==20.0.4"
-hashedixsearch = "==0.2.0"
+hashedixsearch = "==0.2.2"
 stop-words = "==2018.7.23"
 snowballstemmer = "==2.0.0"
 

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -22,8 +22,8 @@ def test_description_parsing(client):
             'markup': 'Pre-heat the <mark>oven</mark> to 250 degrees F.',
             'appliances': [{'appliance': 'oven'}],
         },
-        'leave the slow cooker on a low heat': {
-            'markup': 'leave the <mark>slow cooker</mark> on a low heat',
+        'leave the Slow cooker, on a low heat': {
+            'markup': 'leave the <mark>Slow cooker</mark>, on a low heat',
             'appliances': [{'appliance': 'slow cooker'}],
         },
         'place casserole dish in oven': {

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -22,8 +22,8 @@ def test_description_parsing(client):
             'markup': 'Pre-heat the <mark>oven</mark> to 250 degrees F.',
             'appliances': [{'appliance': 'oven'}],
         },
-        'leave the Slow cooker, on a low heat': {
-            'markup': 'leave the <mark>Slow cooker</mark>, on a low heat',
+        'leave the Slow cooker on a low heat': {
+            'markup': 'leave the <mark>Slow cooker</mark> on a low heat',
             'appliances': [{'appliance': 'slow cooker'}],
         },
         'place casserole dish in oven': {

--- a/web/app.py
+++ b/web/app.py
@@ -93,7 +93,8 @@ def root():
         markup_by_doc[doc_id] = highlight(
             query=description,
             terms=terms,
-            stemmer=stemmer
+            stemmer=stemmer,
+            case_sensitive=False
         )
 
     results = []


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Currently equipment names are stored lowercase, but are intended to match regardless of description text case.

### Briefly summarize the changes
1. Enable case-insensitive highlight matching via `hashedixsearch`

### How have the changes been tested?
1. Test coverage is provided