### PR TITLE
Migrate direction queries to knowledge-graph service

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,10 +9,9 @@ python_version = "3.8"
 [packages]
 flask = "==1.1.2"
 gunicorn = "==20.0.4"
-hashedixsearch = "==0.2.5"
-stop-words = "==2018.7.23"
-snowballstemmer = "==2.0.0"
+requests = "==2.22.0"
 
 [dev-packages]
 flake8 = "*"
 pytest = "*"
+responses = "*"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+import responses
 
 from web.app import app
 
@@ -6,3 +7,14 @@ from web.app import app
 @pytest.fixture
 def client():
     return app.test_client()
+
+
+@pytest.fixture
+def knowledge_graph_stub():
+    with responses.RequestsMock() as response:
+        response.add(
+            responses.POST,
+            'http://knowledge-graph-service/equipment/query',
+            status=500
+        )
+        yield response

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,29 +1,7 @@
-def test_description_parsing(client):
+def test_request(client, knowledge_graph_stub):
     description_equipment = {
-        'Pre-heat the oven to 250 degrees F.': {
-            'markup': 'Pre-heat the <mark>oven</mark> to 250 degrees F.',
-            'appliances': [{'appliance': 'oven'}],
-        },
-        'leave the Slow cooker on a low heat': {
-            'markup': 'leave the <mark>Slow cooker</mark> on a low heat',
-            'appliances': [{'appliance': 'slow cooker'}],
-        },
-        'place casserole dish in oven': {
-            'markup': 'place <mark>casserole dish</mark> in <mark>oven</mark>',
-            'appliances': [{'appliance': 'oven'}],
-            'vessels': [{'vessel': 'casserole dish'}],
-        },
-        'empty skewer into the karahi': {
-            'markup': 'empty <mark>skewer</mark> into the <mark>karahi</mark>',
-            'utensils': [{'utensil': 'skewer'}],
-            'vessels': [{'vessel': 'karahi'}],
-        },
     }
-
     response = client.post('/', data={
         'descriptions[]': list(description_equipment.keys())
     })
-    for result in response.json:
-        assert result['description'] in description_equipment
-        for key, value in description_equipment[result['description']].items():
-            assert result[key] == value
+    assert response.status_code == 500

--- a/web/app.py
+++ b/web/app.py
@@ -1,105 +1,16 @@
-from collections import defaultdict
 from flask import Flask, jsonify, request
-from hashedixsearch import (
-   build_search_index,
-   execute_queries,
-   highlight,
-   tokenize,
-   NullStemmer,
-)
-from snowballstemmer import stemmer
-from stop_words import get_stop_words as get_stopwords
-
-
-def load_queries(filename):
-    with open(filename) as f:
-        return [line.strip().lower() for line in f.readlines()]
-
-
-class EquipmentStemmer(NullStemmer):
-
-    stemmer_en = stemmer('english')
-
-    def stem(self, x):
-        return self.stemmer_en.stemWord(x)
+import requests
 
 
 app = Flask(__name__)
-
-stopwords = get_stopwords('en')
-
-appliance_queries = load_queries('web/data/appliances.txt')
-utensil_queries = load_queries('web/data/utensils.txt')
-vessel_queries = load_queries('web/data/vessels.txt')
-
-
-def equipment_by_document(index, queries):
-    results_by_document = defaultdict(lambda: set())
-    stemmer = EquipmentStemmer()
-    equipment_hits = execute_queries(
-        index=index,
-        queries=queries,
-        stemmer=stemmer,
-        stopwords=stopwords
-    )
-    for equipment, hits in equipment_hits:
-        for hit in hits:
-            results_by_document[hit['doc_id']].add(equipment)
-    return results_by_document
 
 
 @app.route('/', methods=['POST'])
 def root():
     descriptions = request.form.getlist('descriptions[]')
-
-    stemmer = EquipmentStemmer()
-    index = build_search_index()
-    for doc_id, doc in enumerate(descriptions):
-        for ngrams in [1, 2]:
-            for term in tokenize(doc,
-                                 stopwords=stopwords,
-                                 ngrams=ngrams,
-                                 stemmer=stemmer):
-                index.add_term_occurrence(term, doc_id)
-
-    appliances_by_doc = equipment_by_document(index, appliance_queries)
-    utensils_by_doc = equipment_by_document(index, utensil_queries)
-    vessels_by_doc = equipment_by_document(index, vessel_queries)
-
-    markup_by_doc = {}
-    for doc_id, description in enumerate(descriptions):
-        equipment = (
-            appliances_by_doc[doc_id]
-            | utensils_by_doc[doc_id]
-            | vessels_by_doc[doc_id]
-        )
-        terms = []
-        for equipment in equipment:
-            terms.append(next(tokenize(equipment, stemmer=stemmer)))
-        markup_by_doc[doc_id] = highlight(
-            query=description,
-            terms=terms,
-            stemmer=stemmer,
-            case_sensitive=False
-        )
-
-    results = []
-    for doc_id, description in enumerate(descriptions):
-        results.append({
-            'index': doc_id,
-            'description': description,
-            'markup': markup_by_doc.get(doc_id),
-            'appliances': [
-                {'appliance': appliance}
-                for appliance in appliances_by_doc[doc_id]
-            ],
-            'utensils': [
-                {'utensil': utensil}
-                for utensil in utensils_by_doc[doc_id]
-            ],
-            'vessels': [
-                {'vessel': vessel}
-                for vessel in vessels_by_doc[doc_id]
-            ],
-        })
-    return jsonify(results)
+    equipment_data = requests.post(
+        url='http://knowledge-graph-service/equipment/query',
+        data={'descriptions[]': descriptions},
+        proxies={}
+    )
+    return jsonify(equipment_data.json())


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Modeling and extraction of `equipment` entities is moving into the `knowledge-graph` service, as explained in openculinary/knowledge-graph#41.

This changeset removes the migrated functionality from the direction parsing service.

**List any issues that this change relates to**
Relates to openculinary/knowledge-graph#41